### PR TITLE
Bugfix/global nav

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -3,11 +3,13 @@ import '../../styles/vars.css';
 import '../../styles/global.css';
 import React from 'react';
 import styles from './Layout.module.scss';
+import Navigation from '../Navigation/Navigation';
 
 const backgroundTransitionColors = ['#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 
 export default ({ children }) => (
   <>
+    <Navigation />
     <div className={styles.container}>{children}</div>
     <div
       className={styles.backgroundTransition}

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { Link } from 'gatsby';
 import styles from './Navigation.module.scss';
 
-export default () => (
+const Navigation = () => (
   <nav className={styles.nav}>
     <Link to="/#projects">Projects</Link>
     <Link to="/studio">Studio</Link>
   </nav>
 );
+
+export default Navigation;

--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -4,12 +4,16 @@
   top: 0;
   padding: 1.4rem;
   width: 100%;
-  color: white;
+  color: black;
   font-size: 1.2rem;
   line-height: 1;
-  mix-blend-mode: difference;
   z-index: 999;
   pointer-events: all;
+
+  @supports (mix-blend-mode: difference) {
+    color: white;
+    mix-blend-mode: difference;
+  }
 
   a {
     display: inline-block;

--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -1,19 +1,16 @@
+@import '../../styles/mixins';
+
 .nav {
+  @include blendedText;
   display: flex;
   position: fixed;
   top: 0;
   padding: 1.4rem;
   width: 100%;
-  color: black;
   font-size: 1.2rem;
   line-height: 1;
   z-index: 999;
   pointer-events: all;
-
-  @supports (mix-blend-mode: difference) {
-    color: white;
-    mix-blend-mode: difference;
-  }
 
   a {
     display: inline-block;

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,0 +1,15 @@
+@mixin blendedText {
+  color: black;
+
+  @supports (mix-blend-mode: difference) {
+    color: white;
+    mix-blend-mode: difference;
+  }
+
+  // Bug in iPad Pros (only Pros, perhaps graphics chip related?) means mix-blend-mode is never reapplied after first paint.
+  // This means blending is lost after orientation change.
+  @media only screen and (height: 1024px) and (width: 1366px) and (-webkit-min-device-pixel-ratio: 1.5) and (orientation: landscape) and (hover: none),
+  only screen and (width: 1024px) and (height: 1366px) and (-webkit-min-device-pixel-ratio: 1.5) and (orientation: portrait) and (hover: none) {
+    color: black;
+  }
+}

--- a/src/templates/Home/Home.js
+++ b/src/templates/Home/Home.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
 import Layout from '../../components/Layout/Layout';
-import Navigation from '../../components/Navigation/Navigation';
 import Footer from '../../components/Footer/Footer';
 import ProjectList from './ProjectList/ProjectList';
 import HomeVideo from './HomeVideo/HomeVideo';
@@ -71,7 +70,6 @@ const Home = ({
   return (
     <Layout>
       <SEO pathName={fields.slug} />
-      <Navigation />
       <HomeVideo
         videoUrl={frontmatter.video}
         collaborationCredits={frontmatter.collaborationCredits}

--- a/src/templates/Home/HomeVideo/HomeVideo.module.scss
+++ b/src/templates/Home/HomeVideo/HomeVideo.module.scss
@@ -29,7 +29,6 @@
   width: 100%;
   font-size: 1rem;
   line-height: 1;
-  color: black;
   padding: 1rem 1.4rem;
 }
 

--- a/src/templates/Home/HomeVideo/HomeVideo.module.scss
+++ b/src/templates/Home/HomeVideo/HomeVideo.module.scss
@@ -26,9 +26,13 @@
   width: 100%;
   font-size: 1rem;
   line-height: 1;
-  color: white;
+  color: black;
   padding: 1rem 1.4rem;
-  mix-blend-mode: difference;
+
+  @supports (mix-blend-mode: difference) {
+    color: white;
+    mix-blend-mode: difference;
+  }
 }
 
 .logo {

--- a/src/templates/Home/HomeVideo/HomeVideo.module.scss
+++ b/src/templates/Home/HomeVideo/HomeVideo.module.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/mixins';
+
 .video {
   display: block;
   position: relative;
@@ -21,6 +23,7 @@
 }
 
 .featured-author {
+  @include blendedText;
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -28,11 +31,6 @@
   line-height: 1;
   color: black;
   padding: 1rem 1.4rem;
-
-  @supports (mix-blend-mode: difference) {
-    color: white;
-    mix-blend-mode: difference;
-  }
 }
 
 .logo {
@@ -41,6 +39,7 @@
 }
 
 h1.logo {
+  @include blendedText;
   position: absolute;
   left: 1.4rem;
   top: 40vh;
@@ -49,8 +48,6 @@ h1.logo {
   line-height: 1.1;
   margin: 0;
   letter-spacing: -0.01em;
-  mix-blend-mode: difference;
-  color: white;
 }
 
 @media (min-width: 36rem) {

--- a/src/templates/Project/Project.js
+++ b/src/templates/Project/Project.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import Layout from '../../components/Layout/Layout';
 import ProjectDetail from '../../components/ProjectDetail/ProjectDetail';
-import Navigation from '../../components/Navigation/Navigation';
 import SEO from '../../components/SEO/SEO';
 import BackScrim from './BackScrim/BackScrim';
 
@@ -79,7 +78,6 @@ export default ({
         description={project.intro}
         image={SEOImage}
       />
-      <Navigation />
       <ProjectDetail {...project} />
       <BackScrim returnUrl={returnSlug} />
     </Layout>

--- a/src/templates/Studio/Impression/Impression.module.scss
+++ b/src/templates/Studio/Impression/Impression.module.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/mixins';
+
 .impression {
   height: 100vh;
   display: flex;
@@ -17,12 +19,11 @@
 
   // Target the indicator wrapper with title - Will alsways be last in markdown
   & > div > div:last-of-type {
+    @include blendedText;
     position: absolute;
     top: -0.8rem;
     bottom: 0;
     font-size: var(--font-small);
-    color: #fff;
-    mix-blend-mode: difference;
   }
 }
 

--- a/src/templates/Studio/Studio.js
+++ b/src/templates/Studio/Studio.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import Layout from '../../components/Layout/Layout';
-import Navigation from '../../components/Navigation/Navigation';
 import Footer from '../../components/Footer/Footer';
 import Intro from './Intro/Intro';
 import InfoBlock from './InfoBlock/InfoBlock';
@@ -59,7 +58,6 @@ export const query = graphql`
 export default ({ location, data: { indexPage, studioPage } }) => (
   <Layout>
     <SEO title="Studio" pathName={studioPage.fields.slug} />
-    <Navigation />
     <Intro
       data={{ ...indexPage.frontmatter, ...studioPage.frontmatter }}
       location={location}


### PR DESCRIPTION
Fixes use of `mix-blend-mode` in Global Nav and elsewhere.

- On IE11 and Edge fall back to black, as mix-blend-mode is not supported.
NOTE: Edge is switching to chromium in just over 1 month. Support for blend mode will automatically be reintroduced (@supports mix-blend-mode) once this arrives.

-  On iPad Pros we fallback to black too. 
NOTE:  Very unusual bug. Happens only on iPad Pros (tested 11 and 12), but not on iPad/Mini on any similar version. Must be an obscure bug specific to that graphics card.