### PR TITLE
Fix header video on IE11/Edge

### DIFF
--- a/src/templates/Home/HomeVideo/HomeVideo.module.scss
+++ b/src/templates/Home/HomeVideo/HomeVideo.module.scss
@@ -3,11 +3,26 @@
   position: relative;
   width: 100%;
   height: 100vh;
+  overflow: hidden;
 
   & video {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    @media screen and (orientation: landscape) {
+      width: 100%;
+      height: auto;
+    }
+
+    @media screen and (orientation: portrait) {
+      height: 100%;
+      width: auto;
+    }
+
+    // Microsoft Edge (pre-chromium) supports object-fit: cover only on img tags, but
+    // CSS (obviously) has no concept of element type.
+    @supports (object-fit: cover) and (not (-ms-ime-align:auto)){
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Ensure header video always covers 100vw/100vh, even in browsers without `object-fit` support (or those with questionable support, like Edge)