### PR TITLE
Add Forestry CMS config

### DIFF
--- a/.forestry/front_matter/templates/homepage.yml
+++ b/.forestry/front_matter/templates/homepage.yml
@@ -1,0 +1,58 @@
+---
+label: Homepage
+hide_body: true
+fields:
+- type: text
+  name: templateKey
+  label: templateKey
+  hidden: true
+  default: Home
+- type: textarea
+  name: video
+  label: Video
+  description: Link to Vimeo, YouTube
+- type: field_group
+  name: collaborationCredits
+  label: Collaboration credits
+  fields:
+  - type: text
+    name: collaborator
+    label: Collaborator
+  - type: text
+    name: url
+    label: URL
+    description: Link to website of collaborator
+- name: intro
+  type: textarea
+  default: ''
+  config:
+    required: true
+    wysiwyg: true
+    schema:
+      format: markdown
+  label: Intro
+- type: textarea
+  name: middle
+  label: Middle
+  config:
+    wysiwyg: true
+    schema:
+      format: markdown
+- type: textarea
+  name: address
+  label: Address
+  config:
+    wysiwyg: true
+    schema:
+      format: markdown
+- type: text
+  name: phone
+  label: Phone
+- type: text
+  name: email
+  label: E-mail
+- type: text
+  name: contact
+  label: Contact
+pages:
+- src/pages/index.md

--- a/.forestry/front_matter/templates/project.yml
+++ b/.forestry/front_matter/templates/project.yml
@@ -1,0 +1,109 @@
+---
+label: Project
+hide_body: true
+fields:
+- type: text
+  name: templateKey
+  label: templateKey
+  hidden: true
+  default: Project
+- type: text
+  name: title
+  label: Title
+- type: number
+  name: priority
+  label: Priority
+  description: Used to determine position of project
+- type: textarea
+  name: intro
+  label: Intro
+  description: Short introduction to the project
+  config:
+    wysiwyg: true
+    schema:
+      format: markdown
+    required: true
+- type: field_group
+  name: thumbnail
+  label: Thumbnail
+  fields:
+  - type: file
+    name: image
+    label: Image
+  - type: number
+    name: marginLeft
+    label: Left margin
+  - type: number
+    name: marginTop
+    label: Top margin
+  - type: number
+    name: width
+    label: Width
+  - type: number
+    name: ratio
+    label: Aspect ratio
+- type: field_group_list
+  name: content
+  label: Content
+  fields:
+  - type: field_group
+    name: video
+    fields:
+    - name: url
+      type: text
+      config:
+        required: false
+      label: URL
+    - type: boolean
+      name: autoplay
+      label: Autoplay
+    - type: boolean
+      name: hasControls
+      label: Controls
+    - type: boolean
+      name: isMuted
+      label: Muted
+    - type: boolean
+      name: loops
+      label: Loop
+    label: Video
+    description: Link a video
+  - type: file
+    name: image
+    label: Image
+  - name: Description
+    type: text
+    config:
+      required: false
+    label: Description
+    description: Image or video description
+  - type: number
+    name: marginLeft
+    label: Left margin
+  - type: number
+    name: marginTop
+    label: Top margin
+  - type: number
+    name: width
+    label: Width
+  - type: number
+    name: ratio
+    label: Aspect ratio
+  config:
+    labelField: Description
+- type: field_group_list
+  name: credits
+  label: Credits
+  fields:
+  - type: text
+    name: key
+    label: Key
+    description: What kind of credit? ('With:', 'For:', 'Role:', etc.)
+  - type: text
+    name: value
+    label: Value
+    description: Who is being credited?
+  config:
+    labelField: value
+pages:
+- src/pages/projects/chanel-timebox.md

--- a/.forestry/front_matter/templates/settings.yml
+++ b/.forestry/front_matter/templates/settings.yml
@@ -1,0 +1,23 @@
+---
+label: Settings
+hide_body: true
+fields:
+- type: text
+  name: key
+  label: key
+  hidden: true
+  default: settings
+- type: text
+  name: title
+  label: title
+- type: textarea
+  name: description
+  label: description
+- type: text
+  name: twitterHandle
+  label: twitterHandle
+- type: text
+  name: siteUrl
+  label: siteUrl
+pages:
+- src/site/settings.md

--- a/.forestry/front_matter/templates/studio.yml
+++ b/.forestry/front_matter/templates/studio.yml
@@ -1,0 +1,64 @@
+---
+label: Studio
+hide_body: true
+fields:
+- type: text
+  name: templateKey
+  label: templateKey
+  default: Studio
+  hidden: true
+- type: textarea
+  name: intro
+  config:
+    wysiwyg: true
+    schema:
+      format: markdown
+  label: Intro
+- type: field_group_list
+  name: infoBlock
+  label: Info block
+  fields:
+  - type: field_group_list
+    name: collection
+    label: Collection
+    fields:
+    - type: field_group_list
+      name: images
+      fields:
+      - type: file
+        name: image
+        label: Image
+      - type: text
+        name: caption
+        label: Caption
+      label: Images
+    - type: text
+      name: info
+      label: Info
+    - type: boolean
+      name: showIndicator
+      label: Indicator
+    config:
+      labelField: info
+- type: field_group
+  name: studioImpression
+  label: Studio impression
+  fields:
+  - type: text
+    name: title
+    label: Title
+  - type: field_group_list
+    name: images
+    label: Images
+    fields:
+    - type: file
+      name: image
+      label: Image
+    - type: text
+      name: caption
+      label: Caption
+  - type: boolean
+    name: showIndicator
+    label: Indicator
+pages:
+- src/pages/studio.md

--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -1,0 +1,34 @@
+---
+new_page_extension: md
+auto_deploy: false
+admin_path: static/admin
+webhook_url: 
+sections:
+- type: directory
+  path: src/pages/projects
+  label: Projects
+  create: all
+  match: "**/*"
+  templates:
+  - project
+- type: document
+  path: src/pages/index.md
+  label: Homepage
+- type: document
+  path: src/pages/studio.md
+  label: About
+- type: document
+  path: src/site/settings.md
+  label: Site settings
+upload_dir: static/img
+public_path: static
+front_matter_path: ''
+use_front_matter_path: false
+file_template: ":filename:"
+build:
+  preview_output_directory: public
+  install_dependencies_command: npm install
+  preview_docker_image: node:10
+  mount_path: "/srv"
+  working_dir: "/srv"
+  instant_preview_command: npm run forestry:preview

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "gatsby clean && gatsby build",
     "develop": "NODE_TLS_REJECT_UNAUTHORIZED=0 gatsby develop --host 0.0.0.0 --https",
     "develop:expose": "gatsby clean && npm run develop",
+    "forestry:preview": "gatsby develop -H 0.0.0.0 -p 8080",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,24 +1,18 @@
 ---
 templateKey: Home
-video: >-
-  https://player.vimeo.com/external/219822090.hd.mp4?s=9fcbf6bfec731604e4b4d29e278e676848c2ac20&profile_id=119
+video: https://player.vimeo.com/external/219822090.hd.mp4?s=9fcbf6bfec731604e4b4d29e278e676848c2ac20&profile_id=119
 collaborationCredits:
   collaborator: Mark Prendergast
-  url: 'https://www.instagram.com/prendswash/'
-intro: >-
-  How can we reimagine the digital as a living, breathing part of our physical
+  url: https://www.instagram.com/prendswash/
+intro: How can we reimagine the digital as a living, breathing part of our physical
   world?
-middle: >-
-  We create spaces where the physical and non-physical merge; environments that
-  invite people to play, reflect and connect.
-
+middle: |-
+  We create spaces where the physical and non-physical merge; environments that invite people to play, reflect and connect.
 
   [More about our studio](/studio)
-address: >
-  Westzaanstraat 10<br /> 1013 NG Amsterdam<br /> The Netherlands<br />
-  [Directions](https://goo.gl/maps/7rGuGBBfhms)
-phone: +31 20 779 7735
+address: "Westzaanstraat 10  \n1013 NG Amsterdam  \nThe Netherlands  \n[Directions](https://goo.gl/maps/7rGuGBBfhms)"
+phone: "+31 20 779 7735"
 email: hello@random.studio
 contact: hello@random.studio
----
 
+---

--- a/src/pages/projects/chanel-timebox.md
+++ b/src/pages/projects/chanel-timebox.md
@@ -1,123 +1,102 @@
 ---
 templateKey: Project
 title: A vertical journey through time for Chanel
-intro: >-
-  French fashion house Chanel is known for a continuous strive for excellence
-  and perfection. For the introduction of the Chanel Première Camélia Skeleton
-  watch at the international watch show Baselworld 2017, we translated the
-  qualities of the precious watch into a memorable, intimate voyage.
+intro: French fashion house Chanel is known for a continuous strive for excellence
+  and perfection. For the introduction of the Chanel Première Camélia Skeleton watch
+  at the international watch show Baselworld 2017, we translated the qualities of
+  the precious watch into a memorable, intimate voyage.
 priority: 6
 thumbnail:
-  image: /img/chanel1.jpg
-  marginLeft: 0
+  image: "/img/chanel1.jpg"
+  marginLeft: 
   marginTop: -29
-  ratio: 0
+  ratio: 
   width: 35
 content:
-  - image: /img/chanel2.jpg
-    marginLeft: 5
-    marginTop: 1
-    ratio: 0
-    video:
-      autoplay: false
-      hasControls: false
-      isMuted: true
-      loops: true
-    width: 90
-  - caption: >-
-      Called Chanel Timebox, the Chanel booth was morphed into a modern-day time
-      machine that invited visitors on a vertical journey through space and
-      time. Only a single visitor at a time could embark by setting foot on the
-      floor part of the unusual L-shaped screen that made up the dynamic booth,
-      providing for an individual experience.
-    marginLeft: 0
-    marginTop: 0
-    ratio: 0
-    video:
-      autoplay: false
-      hasControls: false
-      isMuted: true
-      loops: true
-  - marginLeft: 6
-    marginTop: 0
-    ratio: 56
-    video:
-      autoplay: true
-      hasControls: false
-      isMuted: true
-      loops: true
-      url: >-
-        https://player.vimeo.com/external/213066493.hd.mp4?s=6dc1f03cb0c4baf32eb60bf3a851feb7cbc001d2&profile_id=119
-    width: 90
-  - caption: >-
-      Acknowledging the octagonal design of the watch case, the journey took off
-      at the similar-shaped Place Vendôme in Paris, from which curious visitors
-      were warped into the galaxy.
-    image: /img/chanel3.jpg
-    marginLeft: 56
-    marginTop: 10
-    ratio: 0
-    video:
-      autoplay: false
-      hasControls: false
-      isMuted: true
-      loops: true
-    width: 45
-  - image: /img/chanel4.jpg
-    marginLeft: 8
-    marginTop: -40
-    ratio: 0
-    video:
-      autoplay: false
-      hasControls: false
-      isMuted: true
-      loops: true
-    width: 38
-  - image: /img/chanel5.jpg
-    marginLeft: 25
-    marginTop: 10
-    ratio: 0
-    video:
-      autoplay: false
-      hasControls: false
-      isMuted: true
-      loops: true
-    width: 50
-  - caption: >-
-      Guests travelled through the camelia-shaped heart of the watch where the
-      highly detailed mechanics and intrinsic aesthetics can be observed that
-      are normally invisible to the naked eye. A shareable video of the journey
-      was offered to each participant afterwards.
-    marginLeft: 0
-    marginTop: 0
-    ratio: 0
-    video:
-      autoplay: false
-      hasControls: false
-      isMuted: true
-      loops: true
-  - marginLeft: 0
-    marginTop: 0
-    ratio: 29
-    video:
-      autoplay: true
-      hasControls: false
-      isMuted: true
-      loops: true
-      url: >-
-        https://player.vimeo.com/external/221734975.hd.mp4?s=e3648ce5f661f3b6da62d0d2c17020846180b57f&profile_id=174
-    width: 100
+- image: "/img/chanel2.jpg"
+  marginLeft: 5
+  marginTop: 1
+  ratio: 
+  video:
+    autoplay: false
+    hasControls: false
+    isMuted: true
+    loops: true
+    url: ''
+  width: 90
+  Description: Chanel timebox
+- marginLeft: 6
+  marginTop: 
+  ratio: 56
+  video:
+    autoplay: true
+    hasControls: false
+    isMuted: true
+    loops: true
+    url: https://player.vimeo.com/external/213066493.hd.mp4?s=6dc1f03cb0c4baf32eb60bf3a851feb7cbc001d2&profile_id=119
+  width: 90
+  Description: Timebox video
+  image: ''
+- caption: Acknowledging the octagonal design of the watch case, the journey took
+    off at the similar-shaped Place Vendôme in Paris, from which curious visitors
+    were warped into the galaxy.
+  image: "/img/chanel3.jpg"
+  marginLeft: 56
+  marginTop: 10
+  ratio: 
+  video:
+    autoplay: false
+    hasControls: false
+    isMuted: true
+    loops: true
+    url: ''
+  width: 45
+  Description: Person standing inside timebox
+- image: "/img/chanel4.jpg"
+  marginLeft: 8
+  marginTop: -40
+  ratio: 
+  video:
+    autoplay: false
+    hasControls: false
+    isMuted: true
+    loops: true
+    url: ''
+  width: 38
+  Description: Person standing inside timebox
+- image: "/img/chanel5.jpg"
+  marginLeft: 25
+  marginTop: 10
+  ratio: 
+  video:
+    autoplay: false
+    hasControls: false
+    isMuted: true
+    loops: true
+    url: ''
+  width: 50
+  Description: Close up of interior floor
+- marginLeft: 
+  marginTop: 
+  ratio: 29
+  video:
+    autoplay: true
+    hasControls: false
+    isMuted: true
+    loops: true
+    url: https://player.vimeo.com/external/221734975.hd.mp4?s=e3648ce5f661f3b6da62d0d2c17020846180b57f&profile_id=174
+  width: 100
+  Description: Triptych video
+  image: ''
 credits:
-  - key: 'For:'
-    value: Chanel
-  - key: 'Role:'
-    value: >-
-      Concept Development, Creative Direction, Design, Content Production,
-      Software Development, App Design and Development, Video Editing,
-      Animation, Sound Design, Set Design.
-  - key: 'With:'
-    value: >-
-      Heerko Groefsema — 3D Animation, Menno Fokma — Film and Motion Direction,
-      Marius Denisse — 3D Animation
----
+- key: 'For:'
+  value: Chanel
+- key: 'Role:'
+  value: Concept Development, Creative Direction, Design, Content Production, Software
+    Development, App Design and Development, Video Editing, Animation, Sound Design,
+    Set Design.
+- key: 'With:'
+  value: Heerko Groefsema — 3D Animation, Menno Fokma — Film and Motion Direction,
+    Marius Denisse — 3D Animation
 
+---

--- a/src/pages/studio.md
+++ b/src/pages/studio.md
@@ -1,113 +1,88 @@
 ---
 templateKey: Studio
-intro: >-
-  Random is an independent experience design studio.<br /> We are strategists,
-  designers and engineers from all over the world, collaborating with brands to
-  trigger curiosity and use technology to spark new, unexpected connections
-  between people and the space around them.
-
-  <br> <br>
-
-  How can we make the digital a living, breathing part of our world? How can
-  technology be integrated into the very foundations of a space; as part of our
-  physical world, engaging us to explore, play and wonder?
-
-  <br> <br>
-
-  We have a holistic, research-led approach that can be applied to products,
-  experiences and platforms where spatial and digital design are integrated.
+intro: "Random is an independent experience design studio.  \nWe are strategists,
+  designers and engineers from all over the world, collaborating with brands to trigger
+  curiosity and use technology to spark new, unexpected connections between people
+  and the space around them.  \n  \nHow can we make the digital a living, breathing
+  part of our world? How can technology be integrated into the very foundations of
+  a space; as part of our physical world, engaging us to explore, play and wonder?
+  \ \n  \nWe have a holistic, research-led approach that can be applied to products,
+  experiences and platforms where spatial and digital design are integrated."
 infoBlock:
-  - collection:
-      - images:
-          - caption: >-
-              [Exhibition for Louis
-              Vuitton](https://random.studio/projects/travel-exhibition-louis-vuitton)
-            image: /img/connected-space-02-lv-2x.jpg
-          - caption: >-
-              [In-store Installations for
-              NikeLab](https://random.studio/projects/NikeLab-ACG)
-            image: /img/connected-space-01-Nike-ACG@2x.jpg
-          - caption: >-
-              [Exhibition for
-              Hermès](https://random.studio/projects/hermes-festival-des-metiers)
-            image: /img/connected-space-03-Hermes@2x.jpg
-        info: ''
-        showIndicator: true
-      - info: >-
-          Connected Spaces
+- collection:
+  - images:
+    - caption: "[Exhibition for Louis Vuitton](https://random.studio/projects/travel-exhibition-louis-vuitton)"
+      image: "/img/connected-space-02-lv-2x.jpg"
+    - caption: "[In-store Installations for NikeLab](https://random.studio/projects/NikeLab-ACG)"
+      image: "/img/connected-space-01-Nike-ACG@2x.jpg"
+    - caption: "[Exhibition for Hermès](https://random.studio/projects/hermes-festival-des-metiers)"
+      image: "/img/connected-space-03-Hermes@2x.jpg"
+    info: ''
+    showIndicator: true
+  - info: |-
+      Connected Spaces
 
+      Blending digital and physical space, we create immersive, sensory experiences that open new worlds and evoke a sense of wonder. Our interactive environments are shaped by connectivity: they use technology in a tactile way, inviting people to play, reflect and explore.
 
-          Blending digital and physical space, we create immersive, sensory
-          experiences that open new worlds and evoke a sense of wonder. Our
-          interactive environments are shaped by connectivity: they use
-          technology in a tactile way, inviting people to play, reflect and
-          explore.
+      * Experiental installations
+      * Exhibitions
+      * In-store experiences
+    showIndicator: false
+    images: []
+- collection:
+  - info: |-
+      Human-Centered Products
 
+      Drawing on in-depth research and technical expertise, we craft holistic global platforms for businesses and consumers that are both relevant and enduring. Extending beyond their primary function, the digital tools we build are experiential and boundary-pushing: they rethink and adapt to the way brands work today.
 
-          * Experiental installations
+      * Consumer and B2B platforms
+      * Omnichannel services
+    showIndicator: false
+    images: []
+  - images:
+    - caption: Shoppable wall for Tommy Hilfiger
+      image: "/img/human-centered-products-02-gigi-shopwall-2x.jpg"
+    - caption: Digital showroom for PVH
+      image: "/img/human-centered-products-02-Digital-Showroom@2x.jpg"
+    showIndicator: true
+    info: ''
+- collection:
+  - images:
+    - caption: "[Website for Raf Simons](https://random.studio/projects/rafsimons)"
+      image: "/img/communication-design-01-raf-simons-2x.jpg"
+    - caption: Communication strategy for Fred Perry
+      image: "/img/communication-design-02-Raf-x-Fred-Perry@2x.jpg"
+    - caption: Interactive documentary 51 Sprints
+      image: "/img/communication-design-03-51-Sprints@2x.jpg"
+    showIndicator: true
+    info: ''
+  - info: |-
+      Communication Formats
 
-          * Exhibitions
+      Sparking new conversations between brands and their audiences, we disrupt existing formats to develop unique ways of communicating. Each project needs its own voice: we play with radical forms that capture the energy and many layers of a story in imaginative and surprising ways.
 
-          * In-store experiences
-        showIndicator: false
-  - collection:
-      - info: >-
-          Human-Centered Products
-
-
-          Drawing on in-depth research and technical expertise, we craft
-          holistic global platforms for businesses and consumers that are both
-          relevant and enduring. Extending beyond their primary function, the
-          digital tools we build are experiential and boundary-pushing: they
-          rethink and adapt to the way brands work today.
-
-
-          * Consumer and B2B platforms
-
-          * Omnichannel services
-        showIndicator: false
-      - images:
-          - caption: Shoppable wall for Tommy Hilfiger
-            image: /img/human-centered-products-02-gigi-shopwall-2x.jpg
-          - caption: Digital showroom for PVH
-            image: /img/human-centered-products-02-Digital-Showroom@2x.jpg
-        showIndicator: true
-  - collection:
-      - images:
-          - caption: '[Website for Raf Simons](https://random.studio/projects/rafsimons)'
-            image: /img/communication-design-01-raf-simons-2x.jpg
-          - caption: Communication strategy for Fred Perry
-            image: /img/communication-design-02-Raf-x-Fred-Perry@2x.jpg
-          - caption: Interactive documentary 51 Sprints
-            image: /img/communication-design-03-51-Sprints@2x.jpg
-        showIndicator: true
-      - info: >-
-          Communication Formats
-
-
-          Sparking new conversations between brands and their audiences, we
-          disrupt existing formats to develop unique ways of communicating. Each
-          project needs its own voice: we play with radical forms that capture
-          the energy and many layers of a story in imaginative and surprising
-          ways.
-
-
-          * Conceptualising new formats
-
-          * Social engagement
-
-          * Film direction and editing
-        showIndicator: false
+      * Conceptualising new formats
+      * Social engagement
+      * Film direction and editing
+    showIndicator: false
+    images: []
 studioImpression:
   images:
-    - image: /img/studio_01.jpg
-    - image: /img/studio_02.jpg
-    - image: /img/studio_03.jpg
-    - image: /img/studio_04.jpg
-    - image: /img/studio_05.jpg
-    - image: /img/studio_06.jpg
-    - image: /img/studio_07.jpg
+  - image: "/img/studio_01.jpg"
+    caption: ''
+  - image: "/img/studio_02.jpg"
+    caption: ''
+  - image: "/img/studio_03.jpg"
+    caption: ''
+  - image: "/img/studio_04.jpg"
+    caption: ''
+  - image: "/img/studio_05.jpg"
+    caption: ''
+  - image: "/img/studio_06.jpg"
+    caption: ''
+  - image: "/img/studio_07.jpg"
+    caption: ''
   showIndicator: true
   title: Studio Impressions
----
 
+---

--- a/src/site/settings.md
+++ b/src/site/settings.md
@@ -1,11 +1,10 @@
 ---
 key: settings
 title: Random Studio
-description: >-
-  Random Studio is an experience design studio. We are an international team of
-  visual artists, strategists and engineers who blur the boundaries between art,
-  design and technology.
-twitterHandle: '@random.studio'
-siteUrl: 'https://random.studio'
----
+description: Random Studio is an experience design studio. We are an international
+  team of visual artists, strategists and engineers who blur the boundaries between
+  art, design and technology.
+twitterHandle: "@random.studio"
+siteUrl: https://random.studio
 
+---

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,38 @@
+<!-- forestryio: ignore; forestryio: admin -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="robots" content="noindex" />
+    <title>Admin</title>
+    <meta name="description" content=" " />
+    <meta name="author" content=" " />
+    <meta name="HandheldFriendly" content="true" />
+    <meta name="MobileOptimized" content="320" />
+    <!-- Use maximum-scale and user-scalable at your own risk. It disables pinch/zoom. Think about usability/accessibility before including.-->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
+    <link rel="stylesheet" href="https://local.forestry.io/main.css" />
+
+    <!-- Google font -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+
+    <!-- Fort awesome icon kit -->
+    <script src="https://use.fortawesome.com/b6f38602.js"></script>
+
+</head>
+<body>
+<div id="app">
+
+</div>
+<script id="admin-config-script" type="text/javascript">
+    var env = {
+        siteId: "iea0wejvw0jyog",
+        local: false
+    };
+</script>
+<script type="application/javascript" src="https://local.forestry.io/forestry.min.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
<img width="1151" alt="Screenshot 2019-12-04 at 11 11 57" src="https://user-images.githubusercontent.com/6472410/70133700-eadcf780-1686-11ea-971c-d0ff9a082c06.png">

Forestry (Forestry.io) offers a cleaner interface than Netlify CMS and easier, more thorough customization options.

This PR:
- Sets up Forestry using config files in `.forestry` folder
- Adds custom front matter templates for each post type
- Adds Forestry Remote (local admin URL at `/admin`, similary to Netlify CMS, this won't work when Netlify CMS is still active)

Please note: some Markdown files have changed due to Forestry using slightly different formatting for multi line content.

Caveats: Forestry's instant preview feature does not work because Gatsby's image processing takes up too much resources. A possible workaround is:
1. Keep letting Forestry commit to the `forestry` branch (this is the current config)
2. Create pull requests after editing a batch of content that generate Netlify preview URLs