### PR TITLE
Fix /projects 404 to redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,3 +16,7 @@
   to = "/"
   status = 200
 
+[[redirects]]
+  from = "/projects"
+  to = "/#projects"
+  status = 200


### PR DESCRIPTION
Redirect `/projects` to `#projects` instead of 404

Will go to `/` as the redirect doens't seem to support internal links