### PR TITLE
Close the joboffer if you return using browser navigation

### DIFF
--- a/src/templates/Studio/Recruitee/Recruitee.js
+++ b/src/templates/Studio/Recruitee/Recruitee.js
@@ -13,6 +13,10 @@ const Recruitee = ({ location }) => {
   };
 
   useEffect(() => {
+    if (!location.hash && openOffer) {
+      handleCloseOffer();
+    }
+
     // If fetch is not supported, we will not show any job offers
     // IE11 and lower
     if (


### PR DESCRIPTION
Close the joboffer if the hash changed (emptied). To accomodate native browser history return