### PR TITLE
Check on ismobile or tablet for clipboard copy desktop only feature

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -8,8 +8,7 @@ const Footer = ({ address, email, phone }) => {
   const [isNoticeVisible, setIsNoticeVisible] = useState(false);
   const emailRef = useRef();
 
-  const handleClickEmail = event =>
-    copyStringToClipboard(event, email, setIsNoticeVisible);
+  const handleClickEmail = event => copyStringToClipboard(event, email, setIsNoticeVisible);
 
   return (
     <footer className={styles.footer}>

--- a/src/utils/checkAndroid.js
+++ b/src/utils/checkAndroid.js
@@ -1,5 +1,5 @@
 const checkAndroid = () => {
-  if (navigator.userAgent.match(/Android|webOS/)) {
+  if (typeof window !== `undefined` && window.navigator.userAgent.match(/Android|webOS/)) {
     return true;
   } else {
     return false;

--- a/src/utils/checkIOS.js
+++ b/src/utils/checkIOS.js
@@ -1,0 +1,6 @@
+// Source: https://stackoverflow.com/a/58064481
+const checkIOS = () => (/iPad|iPhone|iPod/.test(navigator.platform) ||
+(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
+!window.MSStream;
+
+export default checkIOS;

--- a/src/utils/checkIOS.js
+++ b/src/utils/checkIOS.js
@@ -1,6 +1,6 @@
 // Source: https://stackoverflow.com/a/58064481
-const checkIOS = () => (/iPad|iPhone|iPod/.test(navigator.platform) ||
+const checkIOS = () => typeof window !== `undefined` && ((/iPad|iPhone|iPod/.test(navigator.platform) ||
 (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
-!window.MSStream;
+!window.MSStream);
 
 export default checkIOS;

--- a/src/utils/checkIosVersion.js
+++ b/src/utils/checkIosVersion.js
@@ -1,11 +1,13 @@
 const checkVersion = () => {
-  let agent = window.navigator.userAgent,
-    start = agent.indexOf(`OS`);
-  if (
-    (agent.indexOf(`iPhone`) > -1 || agent.indexOf(`iPad`) > -1) &&
-    start > -1
-  ) {
-    return window.Number(agent.substr(start + 3, 3).replace(`_`, `.`));
+  if (typeof window !== `undefined`) {
+    let agent = window.navigator.userAgent,
+      start = agent.indexOf(`OS`);
+    if (
+      (agent.indexOf(`iPhone`) > -1 || agent.indexOf(`iPad`) > -1) &&
+      start > -1
+    ) {
+      return window.Number(agent.substr(start + 3, 3).replace(`_`, `.`));
+    }
   }
   return 0;
 };

--- a/src/utils/copyClipboard.js
+++ b/src/utils/copyClipboard.js
@@ -1,7 +1,14 @@
 // Added minor additions
 // Source: https://techoverflow.net/2018/03/30/copying-strings-to-the-clipboard-using-pure-javascript/
+import checkAndroid from './checkAndroid';
+import checkIOS from './checkIOS';
+
+const isMobile = Boolean(checkAndroid() || checkIOS());
+
 /* eslint-disable import/prefer-default-export */
 export function copyStringToClipboard(event, string, callback) {
+  if (isMobile) return null;
+
   try {
     // Create new element
     const tempElement = document.createElement('textarea');

--- a/src/utils/copyClipboard.js
+++ b/src/utils/copyClipboard.js
@@ -3,7 +3,7 @@
 import checkAndroid from './checkAndroid';
 import checkIOS from './checkIOS';
 
-const isMobile = Boolean(checkAndroid() || checkIOS());
+const isMobile = checkAndroid() || checkIOS();
 
 /* eslint-disable import/prefer-default-export */
 export function copyStringToClipboard(event, string, callback) {


### PR DESCRIPTION
To differentiate between ios/android/tablet for a desktop only feature (well, copy to clipboard can also be used on non desktop, beside the point).

This will now check on what type of device you are and if it is a mobile/tablet (android|ios). It would fallback to the default behavior. For our usage now, it is the behavior of opening the defaulted email client of the device