### PR TITLE
Hotfix/ipad pro mixed blend mode

### DIFF
--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -1,7 +1,7 @@
 @import '../../styles/mixins';
 
 .nav {
-  @include blendedText;
+  @include blendedText(black, normal);
   display: flex;
   position: fixed;
   top: 0;
@@ -9,7 +9,6 @@
   width: 100%;
   font-size: 1.2rem;
   line-height: 1;
-  mix-blend-mode: difference;
   pointer-events: all;
 
   a {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -8,7 +8,10 @@
 
   // Bug in iPad Pros (only Pros 12.9", perhaps graphics chip related?) means mix-blend-mode is never reapplied after first paint.
   // This means blending is lost after orientation change.
-  @media only screen and (min-width: 1023px) and (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait) and (hover: none), only screen and (min-width: 1365px) and (max-width: 1366px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape) and (hover: none) {
+  // Currently, we will remove the blendmode on landscape(orienation change.
+  // Resulting in atleast one orientation working correctly. This is accomplished with he optional parameters
+  // This works because each time the orientation changes a forceful assignement will be done. Thus, the blend-mode will be re-assigned resulting a correct behaviour, albet for jsut one orientation (landscape).
+  @media only screen and (min-width: 1365px) and (max-width: 1366px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape) and (hover: none) {
     color: $color;
     mix-blend-mode: $mode;
   }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -6,11 +6,12 @@
     mix-blend-mode: difference;
   }
 
-  // Bug in iPad Pros (only Pros 12.9", perhaps graphics chip related?) means mix-blend-mode is never reapplied after first paint.
+  // Workaround for bug in iPad Pros (only 12.9 inch, likely GPU related?) where mix-blend-mode is never reapplied after first paint.
   // This means blending is lost after orientation change.
-  // Currently, we will remove the blendmode on landscape(orienation change.
-  // Resulting in atleast one orientation working correctly. This is accomplished with he optional parameters
-  // This works because each time the orientation changes a forceful assignement will be done. Thus, the blend-mode will be re-assigned resulting a correct behaviour, albet for jsut one orientation (landscape).
+  // As a fix, we will remove the blendmode on landscape orienation change resulting in atleast one orientation working correctly. 
+  // This is accomplished through optional parameters.
+  // This works because each time the orientation changes a forceful assignement will be done. 
+  // As a result the blend-mode will be re-assigned resulting a correct behaviour, albeit for just one orientation (landscape).
   @media only screen and (min-width: 1365px) and (max-width: 1366px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape) and (hover: none) {
     color: $color;
     mix-blend-mode: $mode;

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin blendedText {
+@mixin blendedText($color: white, $mode: difference) {
   color: black;
 
   @supports (mix-blend-mode: difference) {
@@ -6,10 +6,10 @@
     mix-blend-mode: difference;
   }
 
-  // Bug in iPad Pros (only Pros, perhaps graphics chip related?) means mix-blend-mode is never reapplied after first paint.
+  // Bug in iPad Pros (only Pros 12.9", perhaps graphics chip related?) means mix-blend-mode is never reapplied after first paint.
   // This means blending is lost after orientation change.
-  @media only screen and (height: 1024px) and (width: 1366px) and (-webkit-min-device-pixel-ratio: 1.5) and (orientation: landscape) and (hover: none),
-  only screen and (width: 1024px) and (height: 1366px) and (-webkit-min-device-pixel-ratio: 1.5) and (orientation: portrait) and (hover: none) {
-    color: black;
+  @media only screen and (min-width: 1023px) and (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait) and (hover: none), only screen and (min-width: 1365px) and (max-width: 1366px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape) and (hover: none) {
+    color: $color;
+    mix-blend-mode: $mode;
   }
 }


### PR DESCRIPTION
As mentioned in trello - for now we will continue with option 1:
Keeping the blend mode on portrait and removing it on landscape.

Background:
The blend mode on ipad does not work as expected. This is only for specific models namely all the 12.9" ipad pros. When the blend mode is assigned to a position fixes element, it will nor repaint (pretty much remove the blend mode) after a orientation change and possibly a size/width change (not tested).

This could be a GPU issue/differentiation of the device.

This PR is a css compromise. It is possible to use JS to fix this issue for this particular case, but not sure the compromise to make a change for this specific audience is worth the possible trade for the majority.