### PR TITLE
Fix showing the toast on desktop size

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,15 +1,15 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import Newsletter from './Newsletter/Newsletter';
 import styles from './Footer.module.scss';
 import { copyStringToClipboard } from '../../utils/copyClipboard';
 
-const Footer = ({ address, email, phone }) => {
-  const [isNoticeVisible, setIsNoticeVisible] = useState(false);
+const Footer = ({ address, email, phone, setCopyToastVisible }) => {
   const emailRef = useRef();
 
   const handleClickEmail = event =>
-    copyStringToClipboard(event, email, setIsNoticeVisible);
+    copyStringToClipboard(event, email, setCopyToastVisible);
 
   return (
     <footer className={styles.footer}>
@@ -40,14 +40,15 @@ const Footer = ({ address, email, phone }) => {
         </div>
       </div>
       <Newsletter />
-      <div
-        className={`${styles.notice} ${isNoticeVisible &&
-          styles.noticeIsVisible}`}
-      >
-        Copied to clipboard
-      </div>
     </footer>
   );
 };
+
+Footer.propTypes = {
+  address: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
+  phone: PropTypes.string.isRequired,
+  setCopyToastVisible: PropTypes.func.isRequired,
+}
 
 export default Footer;

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,15 +1,17 @@
-import React, { useRef } from 'react';
+import React, { useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import Newsletter from './Newsletter/Newsletter';
 import styles from './Footer.module.scss';
 import { copyStringToClipboard } from '../../utils/copyClipboard';
+import { AppContext } from '../../utils/context/AppContext';
 
-const Footer = ({ address, email, phone, setCopyToastVisible }) => {
+const Footer = ({ address, email, phone }) => {
   const emailRef = useRef();
+  const { setIsToastVisible } = useContext(AppContext);
 
-  const handleClickEmail = event =>
-    copyStringToClipboard(event, email, setCopyToastVisible);
+  const handleClickEmail = (event) =>
+    copyStringToClipboard(event, email, setIsToastVisible);
 
   return (
     <footer className={styles.footer}>
@@ -48,7 +50,6 @@ Footer.propTypes = {
   address: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   phone: PropTypes.string.isRequired,
-  setCopyToastVisible: PropTypes.func.isRequired,
 }
 
 export default Footer;

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -73,23 +73,3 @@
 .email-value {
   display: none !important;
 }
-
-.notice {
-  font-size: var(--font-xs);
-  background-color: black;
-  color: white;
-  position: fixed;
-  bottom: 2rem;
-  left: 50%;
-  opacity: 0;
-  transition: opacity 300ms ease-out 0ms, transform 1ms cubic-bezier(0.175, 0.885, 0.32, 1.275) 301ms;
-  transform: translateX(-50%) translateY(4rem);
-  padding: 0 0.75rem;
-  border-radius: 1rem;
-}
-
-.notice-is-visible {
-  transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  transform: translateX(-50%) translateY(0);
-  opacity: 1;
-}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -4,22 +4,33 @@ import '../../styles/global.css';
 import React from 'react';
 import styles from './Layout.module.scss';
 import Navigation from '../Navigation/Navigation';
+import { AppProvider } from '../../utils/context/AppContext';
+import Toast from '../Toast/Toast';
+import { useToastVisibility } from '../../utils/hooks/useToastVisiblity';
 
 const backgroundTransitionColors = ['#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 
-export default ({ children }) => (
-  <>
-    <Navigation />
-    <div className={styles.container}>{children}</div>
-    <Navigation />
-    <div
-      className={styles.backgroundTransition}
-      style={{
-        backgroundColor:
-          backgroundTransitionColors[
-            Math.floor(Math.random() * backgroundTransitionColors.length)
-          ],
-      }}
-    />
-  </>
-);
+const Layout = ({ children }) => {
+  const toastVisiblity = useToastVisibility();
+
+  return (
+  <AppProvider value={toastVisiblity}>
+    <>
+      <Navigation />
+      <div className={styles.container}>{children}</div>
+      <Navigation />
+      <div
+        className={styles.backgroundTransition}
+        style={{
+          backgroundColor:
+            backgroundTransitionColors[
+              Math.floor(Math.random() * backgroundTransitionColors.length)
+            ],
+        }}
+      />
+      <Toast copy="Copied to clipboard" />
+    </>
+  </AppProvider>
+)};
+
+export default Layout;

--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -1,0 +1,16 @@
+import styles from './Toast.module.scss';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Toast = ({ isVisible, copy }) => (
+  <div className={`${styles.notice} ${isVisible && styles.noticeIsVisible}`}>
+    {copy}
+  </div>
+);
+
+  Toast.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    copy: PropTypes.string.isRequired,
+  }
+
+export default Toast;

--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -1,12 +1,16 @@
 import styles from './Toast.module.scss';
-import React from 'react';
+import React, { useContext} from 'react';
 import PropTypes from 'prop-types';
+import { AppContext } from '../../utils/context/AppContext';
 
-const Toast = ({ isVisible, copy }) => (
-  <div className={`${styles.notice} ${isVisible && styles.noticeIsVisible}`}>
+const Toast = ({ copy }) => {
+  const { isToastVisible } = useContext(AppContext);
+
+  return (
+  <div className={`${styles.notice} ${isToastVisible && styles.noticeIsVisible}`}>
     {copy}
   </div>
-);
+);}
 
   Toast.propTypes = {
     isVisible: PropTypes.bool.isRequired,

--- a/src/components/Toast/Toast.module.scss
+++ b/src/components/Toast/Toast.module.scss
@@ -1,0 +1,19 @@
+.notice {
+  font-size: var(--font-xs);
+  background-color: black;
+  color: white;
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  opacity: 0;
+  transition: opacity 300ms ease-out 0ms, transform 1ms cubic-bezier(0.175, 0.885, 0.32, 1.275) 301ms;
+  transform: translateX(-50%) translateY(4rem);
+  padding: 0 0.75rem;
+  border-radius: 1rem;
+}
+
+.notice-is-visible {
+  transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}

--- a/src/templates/Studio/SkillBlock/SkillBlock.js
+++ b/src/templates/Studio/SkillBlock/SkillBlock.js
@@ -1,14 +1,16 @@
-import React, { useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styles from './SkillBlock.module.scss';
 import SkillList from './SkillList/SkillList';
 import { copyStringToClipboard } from '../../../utils/copyClipboard';
+import { AppContext } from '../../../utils/context/AppContext';
 
-const SkillBlock = ({ skillset, email, setCopyToastVisible }) => {
+const SkillBlock = ({ skillset, email }) => {
   const emailRef = useRef();
+  const { setIsToastVisible } = useContext(AppContext);
 
   const handleClickEmail = event =>
-    copyStringToClipboard(event, email, setCopyToastVisible);
+    copyStringToClipboard(event, email, setIsToastVisible);
 
   return (
     <div className={styles.wrapper}>
@@ -27,7 +29,6 @@ const SkillBlock = ({ skillset, email, setCopyToastVisible }) => {
 SkillBlock.propTypes = {
   skillset: PropTypes.arrayOf(PropTypes.string).isRequired,
   email: PropTypes.string.isRequired,
-  setCopyToastVisible: PropTypes.func.isRequired,
 };
 
 export default SkillBlock;

--- a/src/templates/Studio/SkillBlock/SkillBlock.js
+++ b/src/templates/Studio/SkillBlock/SkillBlock.js
@@ -1,15 +1,14 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styles from './SkillBlock.module.scss';
 import SkillList from './SkillList/SkillList';
 import { copyStringToClipboard } from '../../../utils/copyClipboard';
 
-const SkillBlock = ({ skillset, email }) => {
-  const [isNoticeVisible, setIsNoticeVisible] = useState(false);
+const SkillBlock = ({ skillset, email, setCopyToastVisible }) => {
   const emailRef = useRef();
 
   const handleClickEmail = event =>
-    copyStringToClipboard(event, email, setIsNoticeVisible);
+    copyStringToClipboard(event, email, setCopyToastVisible);
 
   return (
     <div className={styles.wrapper}>
@@ -21,13 +20,6 @@ const SkillBlock = ({ skillset, email }) => {
           Contact Us
         </a>
       </div>
-
-      <div
-        className={`${styles.notice} ${isNoticeVisible &&
-          styles.noticeIsVisible}`}
-      >
-        Copied to clipboard
-      </div>
     </div>
   );
 };
@@ -35,6 +27,7 @@ const SkillBlock = ({ skillset, email }) => {
 SkillBlock.propTypes = {
   skillset: PropTypes.arrayOf(PropTypes.string).isRequired,
   email: PropTypes.string.isRequired,
+  setCopyToastVisible: PropTypes.func.isRequired,
 };
 
 export default SkillBlock;

--- a/src/templates/Studio/SkillBlock/SkillBlock.module.scss
+++ b/src/templates/Studio/SkillBlock/SkillBlock.module.scss
@@ -42,24 +42,3 @@
       line-height: 52px;
   }
 }
-
-.notice {
-  font-size: var(--font-xs);
-  background-color: black;
-  color: white;
-  position: fixed;
-  bottom: 32px;
-  left: 50%;
-  opacity: 0;
-  transition: opacity 300ms ease-out 0ms, transform 1ms cubic-bezier(0.175, 0.885, 0.32, 1.275) 301ms;
-  transform: translateX(-50%) translateY(64px);
-  padding: 0 12px;
-  border-radius: 16px;
-  z-index: 1;
-}
-
-.notice-is-visible {
-  transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  transform: translateX(-50%) translateY(0);
-  opacity: 1;
-}

--- a/src/templates/Studio/Studio.js
+++ b/src/templates/Studio/Studio.js
@@ -10,7 +10,6 @@ import Recruitee from './Recruitee/Recruitee';
 import ImageCarousel from '../../components/ImageCarousel/ImageCarousel';
 import SkillBlock from './SkillBlock/SkillBlock';
 import useWindowSize from '../../utils/hooks/useWindowSize';
-import Toast from '../../components/Toast/Toast';
 
 export const query = graphql`
   query Studio($templateKey: String!) {
@@ -87,7 +86,6 @@ const Studio = ({
 }) => {
   const introRef = useRef();
   const [themeClass, setThemeClass] = useState();
-  const [isCopyToastVisible, setCopyToastVisible] = useState(false);
   const { width } = useWindowSize();
 
   useEffect(() => {
@@ -136,7 +134,6 @@ const Studio = ({
         <SkillBlock
           skillset={frontmatter.skillset}
           email={indexPage.frontmatter.email}
-          setCopyToastVisible={setCopyToastVisible}
         />
 
         <div className={styles.jobsImpressionBlock}>
@@ -149,9 +146,8 @@ const Studio = ({
           />
         </div>
 
-        <Footer {...indexPage.frontmatter} setCopyToastVisible={setCopyToastVisible} />
+        <Footer {...indexPage.frontmatter} />
       </div>
-      <Toast isVisible={isCopyToastVisible} copy="Copied to clipboard" />
     </Layout>
   );
 };

--- a/src/templates/Studio/Studio.js
+++ b/src/templates/Studio/Studio.js
@@ -10,6 +10,7 @@ import Recruitee from './Recruitee/Recruitee';
 import ImageCarousel from '../../components/ImageCarousel/ImageCarousel';
 import SkillBlock from './SkillBlock/SkillBlock';
 import useWindowSize from '../../utils/hooks/useWindowSize';
+import Toast from '../../components/Toast/Toast';
 
 export const query = graphql`
   query Studio($templateKey: String!) {
@@ -86,6 +87,7 @@ const Studio = ({
 }) => {
   const introRef = useRef();
   const [themeClass, setThemeClass] = useState();
+  const [isCopyToastVisible, setCopyToastVisible] = useState(false);
   const { width } = useWindowSize();
 
   useEffect(() => {
@@ -134,6 +136,7 @@ const Studio = ({
         <SkillBlock
           skillset={frontmatter.skillset}
           email={indexPage.frontmatter.email}
+          setCopyToastVisible={setCopyToastVisible}
         />
 
         <div className={styles.jobsImpressionBlock}>
@@ -146,8 +149,9 @@ const Studio = ({
           />
         </div>
 
-        <Footer {...indexPage.frontmatter} />
+        <Footer {...indexPage.frontmatter} setCopyToastVisible={setCopyToastVisible} />
       </div>
+      <Toast isVisible={isCopyToastVisible} copy="Copied to clipboard" />
     </Layout>
   );
 };

--- a/src/utils/context/AppContext.js
+++ b/src/utils/context/AppContext.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const appDefaultState = {
+  isToastVisible: false,
+  setIsToastVisible: () => {}
+}
+
+const AppContext = React.createContext(appDefaultState);
+const AppProvider = AppContext.Provider;
+const AppConsumer = AppContext.Consumer;
+
+export { appDefaultState, AppContext, AppConsumer, AppProvider };

--- a/src/utils/hooks/useToastVisiblity.js
+++ b/src/utils/hooks/useToastVisiblity.js
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react';
+
+export const useToastVisibility = () => {
+  const [isToastVisible, setIsVisible] = useState(false);
+
+  const setIsToastVisible = useCallback((isVisible) => {
+    setIsVisible(isVisible);
+  });
+
+  return {
+    isToastVisible, setIsToastVisible
+  }
+}


### PR DESCRIPTION
Before due to the parallax (perspective property) the toast didn't show up anymore. It seems like the property `perpective` will create it's own containment element e.g. like `position: relative`. I've put the toast up a level now instead and have the parent track the state.

Also thought about using `Context` but feels like over-engineering at this point as we are only using it on the same page for two interactions.

Context also re-renders everything either way (depending on the implementation ofc) so this shouldn't be too different. Pray tell if it differs