### PR TITLE
Increase spacing around quote on the homepage

### DIFF
--- a/src/templates/Home/ProjectList/IntermittentBlock/IntermittentBlock.module.scss
+++ b/src/templates/Home/ProjectList/IntermittentBlock/IntermittentBlock.module.scss
@@ -46,6 +46,12 @@
   }
 }
 
+@media (max-width: 480px) {
+  .wrapper {
+    margin: 140px auto 140px;
+  }
+}
+
 @media (min-width: 480px) {
   .wrapper {
     font-size: var(--font-med);

--- a/src/templates/Home/ProjectList/ProjectList.module.scss
+++ b/src/templates/Home/ProjectList/ProjectList.module.scss
@@ -65,10 +65,18 @@
 
 // Force overwrite the inline programmeticly set styles for small screens/mobile
 @media (max-width: 480px) {
+  .projects {
+    padding: 0 0 15vw;
+  }
+
   .thumbnail {
     margin-top: 0 !important;
     margin-left: 0 !important;
     width: 100% !important;
+  }
+
+  .statement {
+    margin: 100px auto 100px;
   }
 }
 


### PR DESCRIPTION
Due to the `vw` based margin and padding the spacing around the quotes on the homepage did not have enough spacing around it. I've opted to specify a fixed `px` size for mobile as specified by Ben.