### PR TITLE
Skip thumbnail cache

### DIFF
--- a/src/api/videos/getVideoData.mjs
+++ b/src/api/videos/getVideoData.mjs
@@ -39,13 +39,12 @@ export const getVideoData = async videoRef => {
   //  const cached = getCachedValue(id);
   const details = await getVideoDetailsById(id);
 
-  const thumbnailUrl = `${baseUrl}/${details.thumbnailFileName}`;
-  const image = await getImage(thumbnailUrl);
-
   if (!details) {
     return null;
   }
 
+  const thumbnailUrl = `${baseUrl}/${details.thumbnailFileName}`;
+  const image = await getImage(thumbnailUrl);
   const { width, height, availableResolutions } = details;
 
   const data = {


### PR DESCRIPTION
When a video is added to the website, at build time, we get the video metadata from Bunny and cache it to avoid gradually slowing down builds/dev reloads as the site grows. Usually this is safe, as values like width/height will never change.

Bunny allows users to select and change a thumbnail via its UI. If a user changes the thumbnail after a video has been deployed, currently, we ignore the change and continue to use the cached version.

As we no longer are limited by an API rate limit against Bunny, for now it makes sense to drop the cache and get the details of videos at build time.